### PR TITLE
collapse `define-language` and  define-language-set`

### DIFF
--- a/Functions1.rkt
+++ b/Functions1.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions1
-  #:reductions func->1
+  #:reductions (func->1)
   #:grammar func-lang-1
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Functions2.rkt
+++ b/Functions2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions2
-  #:reductions func->2
+  #:reductions (func->2)
   #:grammar func-lang-2
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Functions3.rkt
+++ b/Functions3.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions3
-  #:reductions func->3
+  #:reductions (func->3)
   #:grammar func-lang-3
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/FunctionsAll.rkt
+++ b/FunctionsAll.rkt
@@ -2,10 +2,8 @@
 (require "private/mystery-lang.rkt"
          "private/mystery-functions.rkt")
 
-(define-language-set
+(define-language
   #:module-name RacketSchool/FunctionsAll
-  #:reductions1 func->1
-  #:reductions2 func->2
-  #:reductions3 func->3
+  #:reductions (func->1 func->2 func->3)
   #:grammar func-lang-1
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Records1.rkt
+++ b/Records1.rkt
@@ -22,7 +22,7 @@
 (define-syntax (top-interaction stx)
   (syntax-case stx ()
     [(_ . e)
-     #`(#%top-interaction . (run records1 (prog ,@definitions e)))]))
+     #`(#%top-interaction . (run-all record->1 (prog ,@definitions e)))]))
 
 (define-syntax (module-begin stx)
   (syntax-parse stx
@@ -30,7 +30,7 @@
      #`(#%module-begin
         (define defns
           (filter (redex-match? record-lang-1 (defun (x_1 x_2) e_1)) (term (e ...))))
-        (run record->1 (prog e ...)))]))
+        (run-all record->1 (prog e ...)))]))
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; reader

--- a/Records2.rkt
+++ b/Records2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Records2
-  #:reductions record->2
+  #:reductions (record->2)
   #:grammar record-lang-2
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Records3.rkt
+++ b/Records3.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Records3
-  #:reductions record->3
+  #:reductions (record->3)
   #:grammar record-lang-3
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/RecordsAll.rkt
+++ b/RecordsAll.rkt
@@ -2,10 +2,8 @@
 (require "private/mystery-lang.rkt"
          "private/mystery-records.rkt")
 
-(define-language-set
+(define-language
   #:module-name RacketSchool/RecordsAll
-  #:reductions1 record->1
-  #:reductions2 record->2
-  #:reductions3 record->3
+  #:reductions (record->1 record->2 record->3)
   #:grammar record-syntax
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Variables1.rkt
+++ b/Variables1.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Variables1
-  #:reductions var->1
+  #:reductions (var->1)
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Variables2.rkt
+++ b/Variables2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Variables2
-  #:reductions var->2
+  #:reductions (var->2)
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Variables3.rkt
+++ b/Variables3.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Variables3
-  #:reductions var->3
+  #:reductions (var->3)
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/VariablesAll.rkt
+++ b/VariablesAll.rkt
@@ -2,10 +2,8 @@
 (require "private/mystery-lang.rkt"
          "private/mystery-variables.rkt")
 
-(define-language-set
+(define-language
   #:module-name RacketSchool/VariablesAll
-  #:reductions1 var->1
-  #:reductions2 var->2
-  #:reductions3 var->3
+  #:reductions (var->1 var->2 var->3)
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/private/mystery-lang.rkt
+++ b/private/mystery-lang.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(provide define-language define-language-set)
+(provide define-language)
 
 ;; Defines a language like `Records1` in terms of a Redex reduction
 ;; like `records1` --- given the grammar and a pattern for recognizing
@@ -8,101 +8,48 @@
 
 (define-syntax-rule (define-language
                       #:module-name lang-module-name
-                      #:reductions reductions
+                      #:reductions (reductions ...)
                       #:grammar grammar-id
                       #:defn-pattern defn-pattern)
-  (...
-   (begin
-     
-     (provide
-      (rename-out
-       [top-interaction #%top-interaction]
-       [module-begin    #%module-begin]))
+  (begin
+    
+    (provide
+     (rename-out
+      [top-interaction #%top-interaction]
+      [module-begin    #%module-begin]))
 
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; dependencies
+    ;; ---------------------------------------------------------------------------------------------------
+    ;; dependencies
 
-     (require RacketSchool/private/mystery
-              (for-syntax racket/base
-                          syntax/parse)
-              redex/reduction-semantics)
+    (require RacketSchool/private/mystery
+             (for-syntax racket/base
+                         syntax/parse)
+             redex/reduction-semantics)
 
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; implementation
+    ;; ---------------------------------------------------------------------------------------------------
+    ;; implementation
 
-     (define-syntax (top-interaction stx)
-       (syntax-case stx ()
-         [(_ . e)
-          #`(#%top-interaction . (run reductions (prog ,@definitions e)))]))
+    (define-syntax (top-interaction stx)
+      (syntax-case stx ()
+        [(_ . e)
+         #`(#%top-interaction . (run-all reductions ... (prog ,@definitions e)))]))
 
-     (define-syntax (module-begin stx)
-       (syntax-parse stx
-         [(_ defns:id e ...) ; the `defns` identifier is added by the reader
-          #`(#%module-begin
-             (define defns
-               (filter (redex-match? grammar-id defn-pattern) (term (e ...))))
-             (run reductions (prog e ...)))]))
+    (define-syntax (module-begin stx)
+      (syntax-parse stx
+        [(_ defns:id e (... ...)) ; the `defns` identifier is added by the reader
+         #`(#%module-begin
+            (define defns
+              (filter (redex-match? grammar-id defn-pattern) (term (e (... ...)))))
+            (run-all reductions ...  (prog e (... ...))))]))
 
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; reader
+    ;; ---------------------------------------------------------------------------------------------------
+    ;; reader
 
-     (module reader syntax/module-reader
-       lang-module-name
-       
-       #:read read
-       #:read-syntax read-syntax
-       #:wrapper1 (λ (x) (cons 'definitions (x))) ; include `definitions` as if in the original
-       
-       (require racket)))))
-
-
-(define-syntax-rule (define-language-set
-                      #:module-name lang-module-name
-                      #:reductions1 reductions1
-                      #:reductions2 reductions2
-                      #:reductions3 reductions3
-                      #:grammar grammar-id
-                      #:defn-pattern defn-pattern)
-  (...
-   (begin
-     
-     (provide
-      (rename-out
-       [top-interaction #%top-interaction]
-       [module-begin    #%module-begin]))
-
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; dependencies
-
-     (require RacketSchool/private/mystery
-              (for-syntax racket/base
-                          syntax/parse)
-              redex/reduction-semantics)
-
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; implementation
-
-     (define-syntax (top-interaction stx)
-       (syntax-case stx ()
-         [(_ . e)
-          #`(#%top-interaction . (run-all reductions1 reductions2 reduction3 (prog ,@definitions e)))]))
-
-     (define-syntax (module-begin stx)
-       (syntax-parse stx
-         [(_ defns:id e ...) ; the `defns` identifier is added by the reader
-          #`(#%module-begin
-             (define defns
-               (filter (redex-match? grammar-id defn-pattern) (term (e ...))))
-             (run-all reductions1 reductions2 reductions3 (prog e ...)))]))
-
-     ;; ---------------------------------------------------------------------------------------------------
-     ;; reader
-
-     (module reader syntax/module-reader
-       lang-module-name
-       
-       #:read read
-       #:read-syntax read-syntax
-       #:wrapper1 (λ (x) (cons 'definitions (x))) ; include `definitions` as if in the original
-       
-       (require racket)))))
+    (module reader syntax/module-reader
+      lang-module-name
+      
+      #:read read
+      #:read-syntax read-syntax
+      #:wrapper1 (λ (x) (cons 'definitions (x))) ; include `definitions` as if in the original
+      
+      (require racket))))

--- a/private/mystery.rkt
+++ b/private/mystery.rkt
@@ -23,11 +23,8 @@
         'stuck
         x)))
 
-(define-syntax-rule (run-all lang1 lang2 lang3 e)
-  (let ((answer1 (run lang1 e))
-        (answer2 (run lang2 e))
-        (answer3 (run lang3 e)))
-    (values answer1 answer2 answer3)))
+(define-syntax-rule (run-all lang ... e)
+  (values (run lang e) ...))
 
 (define (stuck? e)
   (eq? e 'stuck))


### PR DESCRIPTION
Avoid a copy of a macro.
