### PR TITLE
Add toolbar button for redex stepper.

### DIFF
--- a/Records1.rkt
+++ b/Records1.rkt
@@ -16,6 +16,7 @@
                      syntax/parse)
          redex/reduction-semantics)
 
+
 ;; ---------------------------------------------------------------------------------------------------
 ;; implementation
 
@@ -41,5 +42,30 @@
   #:read read
   #:read-syntax read-syntax
   #:wrapper1 (λ (x) (cons 'definitions (x))) ; include `definitions` as if in the original
+  #:info (λ (key default default-filter)
+      (case key
+        [(drracket:toolbar-buttons)
+         (list
+          (list
+           "Redex Stepper"
+           (make-object bitmap% 16 16) ; a 16 x 16 white square
+           (λ (drr-window)
+             (stepper
+              record->1
+              (let ([mod
+                     (with-module-reading-parameterization
+                         (λ ()
+                           (read
+                            (open-input-string
+                             (send (send drr-window get-definitions-text)
+                                   get-text)))))])
+                (match mod
+                  [`(module ,_ ,_
+                     (#%module-begin
+                      definitions
+                      ,defs ...)) (term (prog ,@defs))])
+                )))))]
+        [else default]))
   
-  (require racket))
+  (require racket redex "private/mystery-records.rkt" syntax/modread racket/draw))
+

--- a/private/mystery-lang.rkt
+++ b/private/mystery-lang.rkt
@@ -1,6 +1,6 @@
-#lang racket/base
-
+#lang racket
 (provide define-language)
+
 
 ;; Defines a language like `Records1` in terms of a Redex reduction
 ;; like `records1` --- given the grammar and a pattern for recognizing
@@ -8,12 +8,13 @@
 
 (define-syntax-rule (define-language
                       #:module-name lang-module-name
-                      #:reductions (reductions ...)
+                      #:reductions (reduction reductions ...)
                       #:grammar grammar-id
                       #:defn-pattern defn-pattern)
   (begin
     
     (provide
+     reduction
      (rename-out
       [top-interaction #%top-interaction]
       [module-begin    #%module-begin]))
@@ -51,5 +52,29 @@
       #:read read
       #:read-syntax read-syntax
       #:wrapper1 (λ (x) (cons 'definitions (x))) ; include `definitions` as if in the original
+      #:info (λ (key default default-filter)
+      (case key
+        [(drracket:toolbar-buttons)
+         (list
+          (list
+           "Redex Stepper"
+           (make-object bitmap% 16 16) ; a 16 x 16 white square
+           (λ (drr-window)
+             (stepper
+              (dynamic-require 'lang-module-name 'reduction)
+              (let ([mod
+                     (with-module-reading-parameterization
+                         (λ ()
+                           (read
+                            (open-input-string
+                             (send (send drr-window get-definitions-text)
+                                   get-text)))))])
+                (match mod
+                  [`(module ,_ ,_
+                     (#%module-begin
+                      definitions
+                      ,defs (... ...))) (term (prog ,@defs))])
+                )))))]
+        [else default]))
       
-      (require racket))))
+      (require racket redex syntax/modread racket/draw))))


### PR DESCRIPTION
These changes cause DrRacket to display a button that opens the redex stepper when any of this package's hashlangs are displayed in the editor:

![2017-07-14-152524_1920x1080_scrot](https://user-images.githubusercontent.com/3820879/28227628-d3e7bec2-68a8-11e7-9f0d-fb62cce7db66.png)

These changes are fully-functional, but there remains a bug: the warning message "_cannot instantiate `racket/gui/base` a second time in the same process_" is displayed in the status bar.
