### PR TITLE
Resolve `racket/gui/base` instantiation error.

### DIFF
--- a/Functions1.rkt
+++ b/Functions1.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions1
-  #:reductions (func->1)
+  #:reductions func->1
   #:grammar func-lang-1
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Functions2.rkt
+++ b/Functions2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions2
-  #:reductions (func->2)
+  #:reductions func->2
   #:grammar func-lang-2
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Functions3.rkt
+++ b/Functions3.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Functions3
-  #:reductions (func->3)
+  #:reductions func->3
   #:grammar func-lang-3
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/FunctionsAll.rkt
+++ b/FunctionsAll.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/FunctionsAll
-  #:reductions (func->1 func->2 func->3)
+  #:reductions func->1 func->2 func->3
   #:grammar func-lang-1
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Records1.rkt
+++ b/Records1.rkt
@@ -45,27 +45,9 @@
   #:info (λ (key default default-filter)
       (case key
         [(drracket:toolbar-buttons)
-         (list
-          (list
-           "Redex Stepper"
-           (make-object bitmap% 16 16) ; a 16 x 16 white square
-           (λ (drr-window)
-             (stepper
-              record->1
-              (let ([mod
-                     (with-module-reading-parameterization
-                         (λ ()
-                           (read
-                            (open-input-string
-                             (send (send drr-window get-definitions-text)
-                                   get-text)))))])
-                (match mod
-                  [`(module ,_ ,_
-                     (#%module-begin
-                      definitions
-                      ,defs ...)) (term (prog ,@defs))])
-                )))))]
+         ((dynamic-require 'RacketSchool/private/stepper 'info)
+          (dynamic-require 'RacketSchool/private/mystery-records 'record->1))]
         [else default]))
   
-  (require racket redex "private/mystery-records.rkt" syntax/modread racket/draw))
+  (require racket))
 

--- a/Records2.rkt
+++ b/Records2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Records2
-  #:reductions (record->2)
+  #:reductions record->2
   #:grammar record-lang-2
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Records3.rkt
+++ b/Records3.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Records3
-  #:reductions (record->3)
+  #:reductions record->3
   #:grammar record-lang-3
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/RecordsAll.rkt
+++ b/RecordsAll.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/RecordsAll
-  #:reductions (record->1 record->2 record->3)
+  #:reductions record->1 record->2 record->3
   #:grammar record-syntax
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Variables1.rkt
+++ b/Variables1.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Variables1
-  #:reductions (var->1)
+  #:reductions var->1
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/Variables2.rkt
+++ b/Variables2.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/Variables2
-  #:reductions (var->2)
+  #:reductions var->2
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/VariablesAll.rkt
+++ b/VariablesAll.rkt
@@ -4,6 +4,6 @@
 
 (define-language
   #:module-name RacketSchool/VariablesAll
-  #:reductions (var->1 var->2 var->3)
+  #:reductions var->1 var->2 var->3
   #:grammar var-lang
   #:defn-pattern  (defun (x_1 x_2) e_1))

--- a/private/mystery-lang.rkt
+++ b/private/mystery-lang.rkt
@@ -8,7 +8,7 @@
 
 (define-syntax-rule (define-language
                       #:module-name lang-module-name
-                      #:reductions (reduction reductions ...)
+                      #:reductions reduction reductions ...
                       #:grammar grammar-id
                       #:defn-pattern defn-pattern)
   (begin

--- a/private/mystery-lang.rkt
+++ b/private/mystery-lang.rkt
@@ -43,6 +43,8 @@
               (filter (redex-match? grammar-id defn-pattern) (term (e (... ...)))))
             (run-all grammar-id reductions ...  (prog e (... ...))))]))
 
+
+    
     ;; ---------------------------------------------------------------------------------------------------
     ;; reader
 
@@ -55,26 +57,8 @@
       #:info (λ (key default default-filter)
       (case key
         [(drracket:toolbar-buttons)
-         (list
-          (list
-           "Redex Stepper"
-           (make-object bitmap% 16 16) ; a 16 x 16 white square
-           (λ (drr-window)
-             (stepper
-              (dynamic-require 'lang-module-name 'reduction)
-              (let ([mod
-                     (with-module-reading-parameterization
-                         (λ ()
-                           (read
-                            (open-input-string
-                             (send (send drr-window get-definitions-text)
-                                   get-text)))))])
-                (match mod
-                  [`(module ,_ ,_
-                     (#%module-begin
-                      definitions
-                      ,defs (... ...))) (term (prog ,@defs))])
-                )))))]
+          ((dynamic-require ''RacketSchool/private/stepper ''info)
+           (dynamic-require 'lang-module-name 'reduction))]
         [else default]))
       
-      (require racket redex syntax/modread racket/draw))))
+      (require racket))))

--- a/private/mystery-lang.rkt
+++ b/private/mystery-lang.rkt
@@ -57,7 +57,7 @@
       #:info (λ (key default default-filter)
       (case key
         [(drracket:toolbar-buttons)
-          ((dynamic-require ''RacketSchool/private/stepper ''info)
+          ((dynamic-require ''RacketSchool/private/stepper 'info)
            (dynamic-require 'lang-module-name 'reduction))]
         [else default]))
       

--- a/private/stepper.rkt
+++ b/private/stepper.rkt
@@ -1,0 +1,27 @@
+#lang racket
+(provide info)
+(require syntax/modread
+         redex
+         racket/gui/base
+         racket/draw)
+
+(define (info reduction)
+  (list
+   (list
+    "Redex Stepper"
+    (make-object bitmap% 16 16)  ; a 16 x 16 white square
+    (λ (drr-window)
+      (stepper
+       reduction
+       (let ([mod
+              (with-module-reading-parameterization
+                  (λ ()
+                    (read
+                     (open-input-text-editor
+                      (send drr-window get-definitions-text)))))])
+         (match mod
+           [`(module ,_ ,_
+               (#%module-begin
+                definitions
+                ,defs ...)) (term (prog ,@defs))])
+         ))))))


### PR DESCRIPTION
These changes correct the "cannot instantiate racket/gui/base a second time in the same process" error introduced by #5:
![](https://user-images.githubusercontent.com/3820879/28227628-d3e7bec2-68a8-11e7-9f0d-fb62cce7db66.png)
